### PR TITLE
Check that wallet directory exists on file system store creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ used with the Hyperledger Fabric version 2.0 SDK for Node.
 ## Example migration from 1.4 to 2.0 wallet format
 
 ```javascript
-import { WalletStores } from "fabric-wallet-migration";
+import * as WalletMigration from "fabric-wallet-migration";
 import { Wallet, Wallets } from "fabric-network";
 
 async function migrateWallet(oldWalletDirectory: string, newWalletDirectory: string) {
-    const walletStore = WalletStores.newFileSystemWalletStore(oldWalletDirectory);
+    const walletStore = await WalletMigration.newFileSystemWalletStore(oldWalletDirectory);
     const oldWallet = new Wallet(walletStore);
 
     const newWallet = await Wallets.newFileSystemWallet(newWalletDirectory);

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,4 @@ stages:
         displayName: Build
 
       - script: npm test
-        displayName: Unit test
-
-      - script: npm run scenario
-        displayName: Scenario test
+        displayName: Test

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,5 +2,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as WalletStores from "./dist/WalletStores";
-export { WalletStores };
+export { newFileSystemWalletStore } from "./dist/WalletStores";

--- a/index.js
+++ b/index.js
@@ -2,4 +2,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-module.exports.WalletStores = require("./dist/WalletStores");
+const WalletStores = require("./dist/WalletStores");
+module.exports.newFileSystemWalletStore = WalletStores.newFileSystemWalletStore;

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
     "name": "fabric-wallet-migration",
-    "version": "0.0.8",
+    "version": "0.1.0",
     "description": "Migration from Hyperledger Fabric 1.4 to 2.0 wallets",
     "main": "index.js",
     "types": "index.d.ts",
     "scripts": {
         "build": "npm run compile && npm run lint",
-        "clean": "rm -rf dist *.tgz",
+        "clean": "rm -rf dist *.tgz scenario/package-lock.json",
         "compile": "tsc",
-        "lint": "eslint . --ext .js,.ts",
+        "lint": "eslint . --ext .ts",
         "scenario": "./runScenario.sh",
-        "test": "jest"
+        "test": "npm run unitTest && npm run scenario",
+        "unitTest": "jest"
     },
     "repository": {
         "type": "git",

--- a/scenario/test/Migrate.spec.ts
+++ b/scenario/test/Migrate.spec.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WalletStores } from "fabric-wallet-migration";
+import * as WalletMigration from "fabric-wallet-migration";
 import { Wallet, Wallets, Identity, X509Identity } from "fabric-network";
 
 import fs = require("fs");
@@ -15,7 +15,7 @@ const rimraf = util.promisify(_rimraf);
 const oldWalletPath = path.resolve(__dirname, "..", "wallet");
 
 async function createTempDir(): Promise<string> {
-    const prefix = path.join(os.tmpdir(), "wallet-");
+    const prefix = path.join(os.tmpdir(), path.sep);
     return await fs.promises.mkdtemp(prefix);
 }
 
@@ -24,7 +24,7 @@ describe("Wallet migration", () => {
     let wallet: Wallet;
 
     async function migrate(): Promise<string[]> {
-        const walletStore = WalletStores.newFileSystemWalletStore(oldWalletPath);
+        const walletStore = await WalletMigration.newFileSystemWalletStore(oldWalletPath);
         const oldWallet = new Wallet(walletStore);
 
         const newWallet = await Wallets.newFileSystemWallet(walletPath);

--- a/src/WalletStores.ts
+++ b/src/WalletStores.ts
@@ -4,13 +4,16 @@
 
 import { FileSystemWalletStoreV1 } from "./FileSystemWalletStoreV1";
 
-interface WalletStore {
+import fs = require("fs");
+
+export interface WalletStore {
     get(label: string): Promise<Buffer | undefined>;
     list(): Promise<string[]>;
     put(label: string, data: Buffer): Promise<void>;
     remove(label: string): Promise<void>;
 }
 
-export function newFileSystemWalletStore(directory: string): WalletStore {
+export async function newFileSystemWalletStore(directory: string): Promise<WalletStore> {
+    await fs.promises.access(directory); // Throws if directory does not exist
     return new FileSystemWalletStoreV1(directory);
 }

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs = require("fs");
+import util = require("util");
+import path = require("path");
+import os = require("os");
+import _rimraf = require("rimraf");
+const rimraf = util.promisify(_rimraf);
+
+export async function readFile(fileName: string): Promise<string> {
+    const filePath = path.resolve(__dirname, fileName);
+    const buffer = await fs.promises.readFile(filePath);
+    return buffer.toString("utf8");
+}
+
+export function stripNewlines(text: string): string {
+    return text.replace(/[\r\n]/g, "");
+}
+
+export async function createTempDir(): Promise<string> {
+    const prefix = path.join(os.tmpdir() + path.sep);
+    return await fs.promises.mkdtemp(prefix);
+}
+
+export async function rmdir(path: string): Promise<void> {
+    await rimraf(path);
+}

--- a/test/WalletStores.spec.ts
+++ b/test/WalletStores.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { newFileSystemWalletStore } from "../src/WalletStores";
+import { createTempDir, rmdir } from "./TestUtils";
+
+describe("WalletStores", () => {
+    it("throws if file system wallet directory does not exist", async () => {
+        const dir = await createTempDir();
+        await rmdir(dir);
+
+        const f = newFileSystemWalletStore(dir);
+
+        await expect(f).rejects.toThrow(dir);
+    });
+});


### PR DESCRIPTION
- Change the API to export just the newFileSystemWalletStore
  factory function.
- newFileSystemWalletStore is now async to enable async I/O.
- Code example in README updated to reflect current API.

Signed-off-by: Mark S. Lewis <Mark.S.Lewis@outlook.com>